### PR TITLE
fix: use radio button instead of checkbox for choosing base

### DIFF
--- a/packages/core/src/components/ColorPalette/VariantRow.tsx
+++ b/packages/core/src/components/ColorPalette/VariantRow.tsx
@@ -14,8 +14,8 @@ import { motion } from 'framer-motion'
 import { useEffect, useState } from 'react'
 import { BsSliders2 } from 'react-icons/bs'
 import {
-  MdOutlineCheckBox,
-  MdOutlineCheckBoxOutlineBlank,
+  MdOutlineRadioButtonUnchecked,
+  MdOutlineRadioButtonChecked
 } from 'react-icons/md'
 import tinycolor from 'tinycolor2'
 
@@ -203,9 +203,9 @@ export function VariantRow({
                 aria-label="Select as base"
                 icon={
                   isBase ? (
-                    <MdOutlineCheckBox />
+                    <MdOutlineRadioButtonChecked />
                   ) : (
-                    <MdOutlineCheckBoxOutlineBlank />
+                    <MdOutlineRadioButtonUnchecked />
                   )
                 }
               />


### PR DESCRIPTION
Slack Discussion: https://mirrorful.slack.com/archives/C054PCE26MT/p1683600430628949?thread_ts=1683565672.785029&cid=C054PCE26MT

It was quicker to do the change instead of prototyping it first 😅 
Here's how it looks. Feel free to discard the PR if we don't want this.

<img width="1107" alt="image" src="https://user-images.githubusercontent.com/20909078/236989384-fe392d6d-d8c9-49b5-a2f3-5dd73decb720.png">
